### PR TITLE
Feature/model

### DIFF
--- a/mitama/db/__init__.py
+++ b/mitama/db/__init__.py
@@ -1,18 +1,50 @@
 #!/usr/bin/python
+'''データベース
 
-from mitama.conf import get_from_project_dir
-from sqlalchemy import scoped_session, sessionmaker
+    * データベースの接続とか抽象化の処理を書きます
+    * Databaseはシングルトンの接続のインスタンスを生成するクラスです
+    * 各アプリにはDatabaseを継承したクラスを定義してもらい、そいつのModelプロパティのベースクラスからモデルを作ってもらいます。
+'''
 
-class Singleton:
-    def __new__(cls, *args, **kargs):
-        if not hasattr(cls, '_instance'):
-            cls._instance = super(Singleton, cls).__new__(cls)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext.declarative.api import DeclarativeMeta
+from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.orm.exc import UnmappedClassError
+from sqlalchemy import *
+from sqlalchemy import orm
+from .model import Model
+from .driver.sqlite3 import get_engine
+
+
+class _Singleton:
+    _instance = None
+    def __new__(cls, *args, **kwargs):
+        if cls._instance == None:
+            cls._instance = super(_Singleton, cls).__new__(cls)
+            print(cls,'instance was generated')
         return cls._instance
 
-class Database(Singleton):
+class _QueryProperty:
+    def __init__(self, db):
+        self.db = db
+    def __get__(self, obj, type):
+        try:
+            mapper = orm.class_mapper(type)
+            if mapper:
+                return type.query_class(
+                    mapper,
+                    session = self.db.session()
+                )
+        except UnmappedClassError:
+            return None
+
+class Database(_Singleton):
     engine = None
     session = None
-    def load_engine(self, engine):
+    def __init__(self, model = None, metadata = None, query_class = orm.Query):
+        self.Query = query_class
+        self.Model = self.make_declarative_base(model, metadata)
+    def set_engine(self, engine):
         self.engine = engine
         self.session = scoped_session(
             sessionmaker(
@@ -21,4 +53,32 @@ class Database(Singleton):
                 bind = engine
             )
         )
+    def make_declarative_base(self, model = None, metadata = None):
+        if model == None:
+            model = Model
+        if not isinstance(model, DeclarativeMeta):
+            model = declarative_base(
+                cls = model,
+                name = 'Model',
+                metadata = metadata
+            )
+        if metadata is not None and model.metadata is not metadata:
+            model.metadata = metadata
+        if not getattr(model, 'query_class', None):
+            model.query_class = self.Query
+        model.query = _QueryProperty(self)
+        return model
+    def session(self):
+        return self.session
+    def create_all(self):
+        self.Model.metadata.create_all(self.engine)
+
+class _CoreDatabase(Database):
+    def __init__(self, engine = None):
+        super().__init__()
+        if self.engine == None:
+            if engine == None:
+                self.set_engine(get_engine())
+            else:
+                self.set_engine(engine)
 

--- a/mitama/db/__init__.py
+++ b/mitama/db/__init__.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+
+from mitama.conf import get_from_project_dir
+from sqlalchemy import scoped_session, sessionmaker
+
+class Singleton:
+    def __new__(cls, *args, **kargs):
+        if not hasattr(cls, '_instance'):
+            cls._instance = super(Singleton, cls).__new__(cls)
+        return cls._instance
+
+class Database(Singleton):
+    engine = None
+    session = None
+    def load_engine(self, engine):
+        self.engine = engine
+        self.session = scoped_session(
+            sessionmaker(
+                autocommit = False,
+                autoflush = False,
+                bind = engine
+            )
+        )
+

--- a/mitama/db/model.py
+++ b/mitama/db/model.py
@@ -5,6 +5,11 @@
     * Djangoのdjango.db.modelsみたいなイメージ
     * データベースはユーザー管理をしているものとは別にしたいので、そのつもりで
     * UserとGroupみたいなカスタム型を使えるようになってると良い
+    * Flaskのsqlalchemy拡張が参考に成る
 '''
 
-import sqlalchemy
+from sqlalchemy.orm import class_mapper
+from sqlalchemy.ext.declarative import declarative_base
+
+class Model:
+    pass

--- a/mitama/nodes.py
+++ b/mitama/nodes.py
@@ -9,23 +9,19 @@ Todo:
     * sqlalchemy用にUser型とGroup型を作って、↓のクラスをそのまま使ってDB呼び出しできるようにしたい
 '''
 
-from sqlalchemy import Column, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
-from mitama.db import types
+from mitama.db import _CoreDatabase, Column, Integer, String
 
-Base = declarative_base()
+db = _CoreDatabase()
 
-class Node:
-    pass
-
-class User(Base, Node):
+class User(db.Model):
     __tablename__ = 'mitama_user'
     id = Column(Integer, primary_key = True)
     name = Column(String(255))
     screen_name = Column(String(255))
     password = Column(String(255))
 
-class Group(Base, Node):
+class Group(db.Model):
     __tablename__ = 'mitama_group'
     id = Column(Integer, primary_key = True)
     name = Column(String(255))

--- a/tests/unit/model.py
+++ b/tests/unit/model.py
@@ -1,0 +1,37 @@
+from mitama.db import _CoreDatabase
+from mitama.db.driver.sqlite3 import get_test_engine
+from sqlalchemy import *
+from sqlalchemy.orm import *
+from datetime import datetime
+
+def create_test_db():
+    engine = get_test_engine()
+    return engine
+
+def create_session(engine):
+    session = scoped_session(
+        sessionmaker(
+            autocommit = False,
+            autoflush = False,
+            bind = engine
+        )
+    )
+    return session
+
+def test_model():
+    engine = create_test_db()
+    db = _CoreDatabase(engine)
+    class Todo(db.Model):
+        __tablename__ = 'test_todo'
+        id = Column(Integer, primary_key = True)
+        title = Column(String(255))
+        description = Column(String(255))
+        datetime = Column(DateTime)
+    db.create_all()
+    session = create_session(engine)
+    session.execute('insert into test_todo (id, title, description, datetime) values (123, "test todo", "this is the test", datetime("2020-08-04 12:00:00"))')
+    test_todo = Todo.query.first()
+    assert test_todo.id == 123
+    assert test_todo.title == 'test todo'
+    assert test_todo.description == 'this is the test'
+    assert test_todo.datetime == datetime(2020, 8, 4, 12)

--- a/tests/unit/nodes.py
+++ b/tests/unit/nodes.py
@@ -1,11 +1,10 @@
-from mitama import nodes
+from mitama.db import _CoreDatabase
 from mitama.db.driver.sqlite3 import get_test_engine
 from sqlalchemy import *
 from sqlalchemy.orm import *
 
 def create_test_db():
     engine = get_test_engine()
-    nodes.Base.metadata.create_all(engine)
     return engine
 
 def create_session(engine):
@@ -18,23 +17,20 @@ def create_session(engine):
     )
     return session
 
-def test_user():
+def test_nodes():
     engine = create_test_db()
+    db = _CoreDatabase(engine)
+    from mitama.nodes import User, Group
+    db.create_all()
     session = create_session(engine)
-    sql = 'insert into mitama_user (id, name, screen_name, password) values (123, "test_user", "test_user_screen", "test_user_password")'
-    session.execute(sql)
-    test_user = session.query(nodes.User).first()
+    session.execute('insert into mitama_user (id, name, screen_name, password) values (123, "test_user", "test_user_screen", "test_user_password")')
+    session.execute('insert into mitama_group (id, name, screen_name) values (456, "test_group", "test_group_screen")')
+    test_user = User.query.first()
+    test_group = Group.query.first()
     assert test_user.id == 123
     assert test_user.name == 'test_user'
     assert test_user.screen_name == 'test_user_screen'
     assert test_user.password == 'test_user_password'
-
-def test_group():
-    engine = create_test_db()
-    session = create_session(engine)
-    sql = 'insert into mitama_group (id, name, screen_name) values (456, "test_group", "test_group_screen")'
-    session.execute(sql)
-    test_group = session.query(nodes.Group).first()
     assert test_group.id == 456
     assert test_group.name == 'test_group'
     assert test_group.screen_name == 'test_group_screen'


### PR DESCRIPTION
Closes #11 
Closes #10 

イシューを2つ同時に消すという禁忌を犯したことをお詫びします。

内容としては、
- データベースへの接続をSingletonパターンで実装するようにしました
- Mitama本体及びアプリケーションは、Singletonのインスタンスの中にいるModelクラス（これがベースモデル）を継承したクラスを定義することでモデルを作ります。
- アプリケーション側でDBを動かす場合にはmitama.db.Databaseを継承した、同様にSingletonのクラスをアプリケーション側で作ってもらうことになります。といっても、クラスを定義する処理もいずれ関数にしてしまうつもりです。

```python
# アプリ側のモデル定義スクリプトのイメージ
from mitama.db import Database
"""
class AppDatabase(Database):
    def __init__(self):
        super().__init__()
        self.set_engine(get_app_engine())
みたいな定義のオブジェクトを返す関数を将来的に定義する
"""
db = get_database()

class Todo(db.Model):
    __tablename__ = 'app_todo'
    title = Column(...)
...
    
```
仕様の大部分は、flask-sqlalchemyのソースコードを参考にしました。
テストが変じゃないか、そもそもアプリを作る上で使いづらい仕様じゃないかを見てほしいです。お願いします。