### PR TITLE
[add]

### DIFF
--- a/mitama/db/model.py
+++ b/mitama/db/model.py
@@ -8,7 +8,7 @@
     * Flaskのsqlalchemy拡張が参考に成る
 '''
 
-from sqlalchemy.orm import class_mapper
+from sqlalchemy.orm import class_mapper, ColumnProperty
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.types import TypeDecorator
 from .types import Column, Integer, String, Node, Group, LargeBinary
@@ -17,6 +17,16 @@ import re
 
 class Model():
     _id = Column(Integer, primary_key = True)
+    @classmethod
+    def attribute_names(cls):
+        return [prop.key for prop in class_mapper(cls).iterate_properties if isinstance(prop, ColumnProperty)]
+    def to_dict(self):
+        attrs = self.attribute_names()
+        d = dict()
+        for k, v in self.__dict__.items():
+            if k in attrs:
+                d[k] = v
+        return d
     @_classproperty
     def type(cls):
         class Type(TypeDecorator):

--- a/mitama/utils/controllers.py
+++ b/mitama/utils/controllers.py
@@ -44,3 +44,149 @@ def static_files(*paths):
             return Response.render(template, status = 404)
     return StaticFileController
 
+class UserCRUDController(Controller):
+    def create(self, request):
+        post = request.post()
+        try:
+            user = User()
+            user.screen_name = post['screen_name']
+            user.name = post['name']
+            user.set_password(post['password'])
+            user.create()
+            return Response.json(user.to_dict())
+        except KeyError as err:
+            error = err
+            return Response.json({
+                'error': err.__class__.__name__,
+                'message': err.message
+                'args': err.args
+            })
+    def retrieve(self, request):
+        try:
+            id = request.params['id']
+            if isdigit(id):
+                user = User.retrieve(int(id))
+            else:
+                user = User.retrieve(screen_name = id)
+            return Response.json(user.to_dict())
+        except KeyError as err:
+            error = err
+            return Response.json({
+                'error': err.__class__.__name__,
+                'message': err.message
+                'args': err.args
+            })
+    def update(self, request):
+        try:
+            post = request.post()
+            id = request.params['id']
+            if isdigit(id):
+                user = User.retrieve(int(id))
+            else:
+                user = User.retrieve(screen_name = id)
+            if 'screen_name' in post: user.screen_name = post['screen_name']
+            if 'name' in post: user.name = post['name']
+            if 'password' in post: user.set_password(post['password'])
+            user.update()
+            return Response.json(user.to_dict())
+        except KeyError as err:
+            error = err
+            return Response.json({
+                'error': err.__class__.__name__,
+                'message': err.message
+                'args': err.args
+            })
+    def delete(self, request):
+        try:
+            id = request.params['id']
+            if isdigit(id):
+                user = User.retrieve(int(id))
+            else:
+                user = User.retrieve(screen_name = id)
+            user.delete()
+            return Response.json({
+                '_id': user._id
+            })
+        except Exception as err:
+            error = err
+            return Response.json({
+                'error': err.__class__.__name__,
+                'message': err.message
+                'args': err.args
+            })
+    def list(self, request):
+        users = User.list()
+        return Response.json([user.to_dict for user in users])
+
+class GroupCRUDController(Controller):
+    def create(self, request):
+        post = request.post()
+        try:
+            group = Group()
+            group.screen_name = post['screen_name']
+            group.name = post['name']
+            group.create()
+            return Response.json(group.to_dict())
+        except KeyError as err:
+            error = err
+            return Response.json({
+                'error': err.__class__.__name__,
+                'message': err.message
+                'args': err.args
+            })
+    def retrieve(self, request):
+        try:
+            id = request.params['id']
+            if isdigit(id):
+                group = Group.retrieve(int(id))
+            else:
+                group = Group.retrieve(screen_name = id)
+            return Response.json(group.to_dict())
+        except KeyError as err:
+            error = err
+            return Response.json({
+                'error': err.__class__.__name__,
+                'message': err.message
+                'args': err.args
+            })
+    def update(self, request):
+        try:
+            post = request.post()
+            id = request.params['id']
+            if isdigit(id):
+                group = Group.retrieve(int(id))
+            else:
+                group = Group.retrieve(screen_name = id)
+            if 'screen_name' in post: group.screen_name = post['screen_name']
+            if 'name' in post: group.name = post['name']
+            group.update()
+            return Response.json(group.to_dict())
+        except KeyError as err:
+            error = err
+            return Response.json({
+                'error': err.__class__.__name__,
+                'message': err.message
+                'args': err.args
+            })
+    def delete(self, request):
+        try:
+            id = request.params['id']
+            if isdigit(id):
+                group = Group.retrieve(int(id))
+            else:
+                group = Group.retrieve(screen_name = id)
+            group.delete()
+            return Response.json({
+                '_id': group._id
+            })
+        except Exception as err:
+            error = err
+            return Response.json({
+                'error': err.__class__.__name__,
+                'message': err.message
+                'args': err.args
+            })
+    def list(self, request):
+        groups = Group.list()
+        return Response.json([group.to_dict() for group in groups])
+

--- a/mitama/utils/routers.py
+++ b/mitama/utils/routers.py
@@ -1,1 +1,42 @@
+from mitama.app import Router
+from .controllers import UserCRUDConrtoller, GroupCRUDController
 
+def create_api_router(middlewares = [SessionMiddleware]):
+    return Router([
+        post('/users', UserCRUDController, 'create'),
+        post('/groups', GroupCRUDController, 'create'),
+    ], middlewares)
+
+def retrieve_api_router(middlewares = []):
+    return Router([
+        get('/users', UserCRUDController, 'list'),
+        get('/users/<id>', UserCRUDController, 'retrieve'),
+        get('/groups', GroupCRUDController, 'list'),
+        get('/groups/<id>', GroupCRUDController, 'retrieve'),
+    ], middlewares)
+
+def update_api_router(middlewares = [SessionMiddleware]):
+    return Router([
+        post('/users/<id>', UserCRUDController, 'update'),
+        post('/groups/<id>', GroupCRUDController, 'update'),
+    ], middlewares)
+
+def delete_api_router(middlewares = [SessionMiddleware]):
+    return Router([
+        delete('/users/<id>', UserCRUDController, 'delete'),
+        delete('/groups/<id>', GroupCRUDController, 'delete'),
+    ], middlewares)
+
+def rest_api_router(middlewares = [SessionMiddleware]):
+    return Router([
+        post('/users', UserCRUDController, 'create'),
+        post('/groups', GroupCRUDController, 'create'),
+        get('/users', UserCRUDController, 'list'),
+        get('/users/<id>', UserCRUDController, 'retrieve'),
+        get('/groups', GroupCRUDController, 'list'),
+        get('/groups/<id>', GroupCRUDController, 'retrieve'),
+        post('/users/<id>', UserCRUDController, 'update'),
+        post('/groups/<id>', GroupCRUDController, 'update'),
+        delete('/users/<id>', UserCRUDController, 'delete'),
+        delete('/groups/<id>', GroupCRUDController, 'delete'),
+    ], middlewares)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -24,3 +24,9 @@ class TestBaseDatabase(unittest.TestCase):
         id = a._id
         a.update()
         self.assertEqual(ModelA.retrieve(id).name, 'world')
+    def test_to_dict(self):
+        a = ModelA.query.one()
+        self.assertEqual(a.to_dict(), {
+            '_id': a._id,
+            'name': a.name,
+        })


### PR DESCRIPTION
## 概要 <!-- 変更機能とIssue番号 -->
Issue closes #110 
現状SPAでアプリを開発しようと思うとUserやGroupのためにAPIを作る必要があってとてもめんどくさいので、Mitama側で予め作っておいて後から付けられるようにしたいです。
```Python
#利用イメージ
from mitama.app import MitamaRestRouter
class App(App):
    router = Router(
        group('/api', MitamaRestRouter),
        view('/', HomeController),
        ...
    )
...
```
## 変更内容 <!-- なにをどう変更したかなど、レビュワーにわかるように、技術的視線での変更概要説明 -->
- UserCRUDControllerとGroupCRUDControllerを追加
- ↑のコントローラーを扱うルーターのジェネレーター関数を、create, update, retrieve, delete, その全ての5つに分けて作成
- APIでの使用上めんどくさい点があったので、モデルにto_dictメソッドを実装。テストを追加
## 影響範囲
## 動作手順 <!-- 手順や動作確認用のURLなど(必要あれば) -->
## 補足 <!-- レビュワーに対する注意点(ここはこう思ったけどこう実装した、こうしようと思ったけどこういう悩みがありやめたなど)や、リリースに対する注意点など -->
## 今回保留した項目とTODOリスト(任意)　<!-- 箇条書きで書く。できれば次のチケットを作る。 -->
 - [ ] #xxx xxxを修正する （担当：xxx）