### PR TITLE
add password validation

### DIFF
--- a/mitama/portal/controller.py
+++ b/mitama/portal/controller.py
@@ -71,6 +71,9 @@ class RegisterController(Controller):
                 return Response.redirect(self.app.convert_url("/"))
             except Exception as err:
                 error = str(err)
+                icon = (
+                    data.get("icon").file.read() if "icon" in data else load_noimage_user()
+                )
                 return Response.render(
                     template,
                     {
@@ -78,7 +81,7 @@ class RegisterController(Controller):
                         "name": data.get("name", invite.name),
                         "screen_name": data.get("screen_name", invite.screen_name),
                         "password": data.get("password", ""),
-                        "icon": data.get("icon").file.read(),
+                        "icon": icon,
                         "editable": invite.editable,
                     },
                 )

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -12,8 +12,8 @@ class TestUser(unittest.TestCase):
         user = User()
         user.name = "alice"
         user.screen_name = "alice"
-        user.set_password("alice_s_password")
+        user.set_password("alice_s_password_1234")
         user.create()
-        self.assertTrue(User.password_auth("alice", "alice_s_password"))
+        self.assertTrue(User.password_auth("alice", "alice_s_password_1234"))
         jwt = user.get_jwt()
         self.assertEqual(User.check_jwt(jwt), user)


### PR DESCRIPTION
## 概要 
Issue #121 
パスワードの検証機能の追加
## 変更内容 
set_passwordにおけるpasswordをvalid_password関数に通し安全なパスワードかどうかを検証することができるように変更
(valid_password関数は別の場所に定義すべきですか？)
## 影響範囲
初期状態ではこの検証を適用しない設定だが、test_userではこの検証を通過するパスワードへと変更している。
(初期値で検証を有効にすべきですか？)
## 動作手順 
この設定の変更はmitama.jsonにおいて"apps"と同じ階層に"password_validation"を置き、その中に"MIN_PASSWORD_LEN"(int)と"COMPLECATED_PASSWORD"(boolean)を記述する。
初期値は検証を適用しない設定としている。
(このmitama.jsonの使い方はあっていますか？)
```
{
  "apps": {
    "mitama.portal": {
      "path": "/"
    }
  },
  "password_validation": {
    "MIN_PASSWORD_LEN": 6,
    "COMPLICATED_PASSWORD": true
  }
}
```