### PR TITLE
request.bodyの実装

### DIFF
--- a/mitama/app/http/request.py
+++ b/mitama/app/http/request.py
@@ -4,9 +4,7 @@ import http.cookies
 import io
 import json
 import wsgiref.util as wsgiutil
-from urllib.parse import parse_qs, urlencode
-
-from yarl import URL
+from urllib.parse import parse_qs
 
 
 class _Cookies:
@@ -147,9 +145,11 @@ class Request:
             length = self.environ.get("CONTENT_LENGTH", 0)
             self._body = self._rfile.read(int(length))
         return self._body
+
     def post(self):
         if hasattr(self, "_post"):
             return self._post
+
         else:
             content_type = self.environ.get("CONTENT_TYPE", "")
             length = self.environ.get("CONTENT_LENGTH", 0)
@@ -192,13 +192,12 @@ class Request:
             raise Exception("Bad Request")
         command, path = words[:2]
         if len(words) == 2:
-            close_connection = True
             if command != "GET":
                 raise Exception("Bad Request")
         try:
             headers = http.client.parse_headers(rfile, _class=cls.MessageClass)
-        except http.client.LineTooLong as err:
+        except http.client.LineTooLong:
             raise Exception("")
-        except http.client.HTTPException as err:
+        except http.client.HTTPException:
             raise Exception("")
         return cls(command, path, version, headers, ssl, rfile)

--- a/mitama/app/http/response.py
+++ b/mitama/app/http/response.py
@@ -13,7 +13,7 @@ class ResponseBase(metaclass=ABCMeta):
         if reason is None:
             try:
                 self._reason = BaseHTTPRequestHandler.responses[self._status][0]
-            except:
+            except KeyError:
                 self._reason = ""
         else:
             self._reason = reason
@@ -138,6 +138,7 @@ class StreamResponse(ResponseBase):
         if len(cookies) > 0:
             headers.extend([("Set-Cookie", cookie) for cookie in cookies.strip("\r\n")])
         headers.append(("Content-Type", self.content_type))
+
         def content():
             nonlocal self, start_response, request, headers
             start_response(("%s %s" % (self._status, self._reason)), headers)

--- a/mitama/app/http/response.py
+++ b/mitama/app/http/response.py
@@ -138,12 +138,15 @@ class StreamResponse(ResponseBase):
         if len(cookies) > 0:
             headers.extend([("Set-Cookie", cookie) for cookie in cookies.strip("\r\n")])
         headers.append(("Content-Type", self.content_type))
-        start_response(("%s %s" % (self._status, self._reason)), headers)
-        for chunk in self.body:
-            if callable(chunk):
-                yield chunk(request)
-            elif chunk is not None:
-                yield chunk
+        def content():
+            nonlocal self, start_response, request, headers
+            start_response(("%s %s" % (self._status, self._reason)), headers)
+            for chunk in self.body:
+                if callable(chunk):
+                    yield chunk(request)
+                elif chunk is not None:
+                    yield chunk
+        return content()
 
     def start(self, request, stream):
         stream.write(

--- a/mitama/app/http/session.py
+++ b/mitama/app/http/session.py
@@ -1,4 +1,3 @@
-import base64
 import json
 import time
 from collections.abc import MutableMapping
@@ -142,7 +141,7 @@ class EncryptedCookieStorage:
                     ).decode("utf-8")
                 )
                 return Session(None, data=data, new=False, max_age=self.max_age)
-            except:
+            except (TypeError, fernet.InvalidToken):
                 return Session(None, data=None, new=True, max_age=self.max_age)
 
     def save_session(self, request, response, session):


### PR DESCRIPTION
## 概要 <!-- 変更機能とIssue番号 -->
Issue closes #120
リクエストの生ボディを取得する仕様
- パース済みのボディしか取得できないので、パース前の生データを取得できるようにしたいです。
## 変更内容 <!-- なにをどう変更したかなど、レビュワーにわかるように、技術的視線での変更概要説明 -->
app.http.request.Requestクラスにbodyプロパティを実装し、postリクエストのパース時はbodyを参照するようにしました。
## 影響範囲
アプリ側からリクエストの生bodyにアクセスできるようになります。他所に影響はありません。
## 動作手順 <!-- 手順や動作確認用のURLなど(必要あれば) -->
## 補足 <!-- レビュワーに対する注意点(ここはこう思ったけどこう実装した、こうしようと思ったけどこういう悩みがありやめたなど)や、リリースに対する注意点など -->
## 今回保留した項目とTODOリスト(任意)　<!-- 箇条書きで書く。できれば次のチケットを作る。 -->
 - [ ] #xxx xxxを修正する （担当：xxx）